### PR TITLE
whilelisting jibri user to start the recording with lobby enabled

### DIFF
--- a/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
+++ b/prosody/rootfs/defaults/conf.d/jitsi-meet.cfg.lua
@@ -68,6 +68,7 @@ VirtualHost "{{ .Env.XMPP_DOMAIN }}"
     {{ if and $ENABLE_LOBBY (not $ENABLE_GUEST_DOMAIN) }}
     main_muc = "{{ .Env.XMPP_MUC_DOMAIN }}"
     lobby_muc = "lobby.{{ .Env.XMPP_DOMAIN }}"
+    muc_lobby_whitelist = "recorder.{{ .Env.XMPP_DOMAIN }}"
     {{ end }}
 
     speakerstats_component = "speakerstats.{{ .Env.XMPP_DOMAIN }}"
@@ -87,6 +88,7 @@ VirtualHost "{{ .Env.XMPP_GUEST_DOMAIN }}"
 
     main_muc = "{{ .Env.XMPP_MUC_DOMAIN }}"
     lobby_muc = "lobby.{{ .Env.XMPP_DOMAIN }}"
+    muc_lobby_whitelist = "recorder.{{ .Env.XMPP_DOMAIN }}"
     {{ end }}
 
 {{ end }}


### PR DESCRIPTION
If Lobby is enable then Jibri is unable to start the recording since it's unable to bypass the Lobby feature. By whitelisting the jibri user, we are allowing the jibri to start the recording even if Lobby is enabled. 

reference: https://github.com/jitsi/docker-jitsi-meet/issues/715